### PR TITLE
useEffect - run effects only once

### DIFF
--- a/learn-hooks/src/App.js
+++ b/learn-hooks/src/App.js
@@ -6,6 +6,8 @@ import HookCounterThree from './components/HookCounterThree';
 import HookCounterFour from './components/HookCounterFour';
 import ClassCounterOne from './components/useEffectHook/ClassCounterOne';
 import HookCounterOne from './components/useEffectHook/HookCounterOne';
+import ClassMouse from './components/useEffectHook/ClassMouse';
+import HookMouse from './components/useEffectHook/HookMouse';
 
 function App() {
   return (
@@ -16,7 +18,9 @@ function App() {
       {/* <HookCounterThree /> */}
       {/* <HookCounterFour /> */}
       {/* <ClassCounterOne /> */}
-      <HookCounterOne />
+      {/* <HookCounterOne /> */}
+      {/* <ClassMouse /> */}
+      <HookMouse />
     </div>
   );
 }

--- a/learn-hooks/src/components/useEffectHook/ClassMouse.js
+++ b/learn-hooks/src/components/useEffectHook/ClassMouse.js
@@ -1,0 +1,29 @@
+import React, {Component} from 'react'
+
+class ClassMouse extends Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            x: 0,
+            y: 0
+        }
+    }
+
+    logMousePosition = e => {
+        this.setState({ x: e.clientX, y: e.clientY})
+    }
+
+    componentDidMount = () => {
+        window.addEventListener('mousemove', this.logMousePosition)
+    }
+
+    render() {
+        return(
+            <div>
+                X - {this.state.x} Y - {this.state.y}
+            </div>
+        )
+    }
+}
+
+export default ClassMouse

--- a/learn-hooks/src/components/useEffectHook/HookMouse.js
+++ b/learn-hooks/src/components/useEffectHook/HookMouse.js
@@ -1,0 +1,26 @@
+import React, {useState, useEffect} from 'react';
+
+function HookMouse() {
+
+    const [x, setX] = useState(0)
+    const [y, setY] = useState(0)
+
+    const logMousePosition = (e) => {
+        console.log('Mouse moved')
+        setX(e.clientX)
+        setY(e.clientY)
+    }
+
+    useEffect(() => {
+        console.log('useEffect called')
+        window.addEventListener('mousemove', logMousePosition)
+    }, [])
+
+    return(
+        <div>
+            X - {x}, Y - {y}
+        </div>
+    )
+}
+
+export default HookMouse

--- a/useEffect.txt
+++ b/useEffect.txt
@@ -33,3 +33,6 @@ useEffect Hook
         & Thus only if the props or state specified in array changes, Effect will be get executed
 
 
+# useEffect - How to run an Effect ONLY ONCE ?
+    + By specifying an empty dependency Array, we can ask react to
+        produce effect only once, i.e on initial render


### PR DESCRIPTION
By specifying an empty dependency array as second argument to useEffect Hook, we can ask react to run the effect ONLY ONCE, i.e during initial render